### PR TITLE
Fix Users data to respect 'is_group' fields that is required for auth pr...

### DIFF
--- a/Data/Users.php
+++ b/Data/Users.php
@@ -51,4 +51,4 @@ $GLOBALS['dataTool']['Users']['user_name'] = array('incname' => 'user');
 $GLOBALS['dataTool']['Users']['user_hash'] = array('same_hash' => 'user_name');
 $GLOBALS['dataTool']['Users']['user_preferences'] = array('skip' => true);
 $GLOBALS['dataTool']['Users']['portal_only'] = array('skip' => true);
-$GLOBALS['dataTool']['Users']['is_group'] = array('skip' => true);
+$GLOBALS['dataTool']['Users']['is_group'] = array('value' => "0");


### PR DESCRIPTION
Fix Users data to respect 'is_group' fields that is required for auth process in current version

Users in current auth version are fetched by this code:

```
    $userBean = $userBean->retrieve_by_string_fields(
        array(
            'user_name'=>$username,
            'deleted'=>'0',
            'status'=>'Active',
            'portal_only'=>'0',
            'is_group'=>'0',
        ));
```

So 'is_group' field should have 0 value for successful login.
