### PR TITLE
add users to teamset with max count teams, fix for sugar 7700beta5

### DIFF
--- a/install_cli.php
+++ b/install_cli.php
@@ -672,7 +672,17 @@ foreach($module_keys as $module)
 		while($row = $GLOBALS['db']->fetchByAssoc($result)){
 			$team_sets[$row['team_set_id']][] = $row['team_id'];
 		}
-		DataTool::$team_sets_array = $team_sets;
+
+		// check teamset with max count teams, fix for sugar 7700beta5
+		$maxTeamSet = null;
+		$teams_in_team_set = 0;
+		foreach($team_sets as $team_set_id => $data) {
+			if (count($data) > $teams_in_team_set) {
+				$maxTeamSet = $team_set_id;
+				$teams_in_team_set = count($data);
+			}
+		}
+		DataTool::$team_sets_array = array($maxTeamSet => $team_sets[$maxTeamSet]);
 	}
 
     // Apply TBA Rules for some modules


### PR DESCRIPTION
This fix set default Beans TeamSetId to TeamSet with maximum teams inside.
So as a result, all Beans will be visible to all Tidbit Users.