### PR TITLE
Automatic Alias Generation

### DIFF
--- a/install_cli.php
+++ b/install_cli.php
@@ -38,6 +38,15 @@
 
 require_once 'bootstrap.php';
 
+/*
+ * impose a hard limit of 99999 on all modules so ensure unique IDs
+ */
+foreach($modules as $module => $count){
+  if($count > 99999){
+    $modules[$module] = 99999;
+  }
+}
+
 //When creating module_keys variable, ensure that Teams and Tags are first in the modules list
 $module_keys = array_keys($modules);
 array_unshift($module_keys, 'Teams');

--- a/install_config.php
+++ b/install_config.php
@@ -70,12 +70,6 @@ $modules = array(
     'KBContents' => 1000,
 );
 
-$aliases = array(
-    'EmailAddresses' => 'Emadd',
-    'ProductBundles' => 'Prodb',
-    'Opportunities' => 'Oppty'
-);
-
 $activityModulesBlackList = array(
     'Users',
     'Teams',

--- a/src/DataTool.php
+++ b/src/DataTool.php
@@ -1096,16 +1096,16 @@ class DataTool
     }
 
     /**
-     * Returns an alias to be used for id generation.
+     * Returns an alias to be used for id generation. To try for a unique alias, 
+     * use the first and last 8 characters of the passed-in name (even if they
+     * overlap)
+     * 
      * @param $name - The current module
      * @return string
      */
     public function getAlias($name)
     {
-        global $aliases;
-        return (isset($aliases[$name]))
-            ? $aliases[$name]
-            : $name;
+        return substr($name, 0, 8) . substr($name, -8);
     }
 
     /**


### PR DESCRIPTION
Automatically generate aliases for all modules used so we don't have to do it manually in config file. An alias should be unique relative to other aliases but short enough to leave enough room for auto-incrementing IDs. 16 characters seems reasonable, but imposes a max of 99999 records per module for a single Tidbit run so we set a hard-coded limit.

Formula for a GUID:

(string 5) "seed-"
(string 16) module identifier
(string 10) time()
(int (1-5)) auto-incrementing ID