### PR TITLE
Automatic Alias Generation

### DIFF
--- a/install_cli.php
+++ b/install_cli.php
@@ -38,6 +38,15 @@
 
 require_once 'bootstrap.php';
 
+/*
+ * impose a hard limit of one hundred billion on all modules to ensure unique IDs
+ */
+foreach ($modules as $module => $count) {
+    if ($count > 100000000000) {
+        $modules[$module] = 100000000000;
+    }
+}
+
 //When creating module_keys variable, ensure that Teams and Users are first in the modules list
 $module_keys = array_keys($modules);
 array_unshift($module_keys, 'Users');

--- a/install_config.php
+++ b/install_config.php
@@ -70,6 +70,13 @@ $modules = array(
     'KBContents' => 1000,
 );
 
+/*
+ * Add a module alias for GUID creation. All records created will have a GUID 
+ * that begins with the string 'seed-', then the module name or this alias, then
+ * a timestamp and an auto incrementing integer. It is recommended that all
+ * module names over 10 characters have a shorter alias to ensure that unique
+ * GUIDs can be created.    
+ */
 $aliases = array(
     'EmailAddresses' => 'Emadd',
     'ProductBundles' => 'Prodb',

--- a/src/DataTool.php
+++ b/src/DataTool.php
@@ -1099,16 +1099,24 @@ class DataTool
     }
 
     /**
-     * Returns an alias to be used for id generation.
+     * Returns an alias to be used for id generation. Always honor the
+     * configured alias if one exists, otherwise for longer module names (over
+     * 10 charactesr), use the first and last 5 characters of the passed-in name
+     * (even if they overlap).
+     *
      * @param $name - The current module
      * @return string
      */
     public function getAlias($name)
     {
         global $aliases;
-        return (isset($aliases[$name]))
-            ? $aliases[$name]
-            : $name;
+        if (isset($aliases[$name])) {
+            return $aliases[$name];
+        } elseif (strlen($name) > 10) {
+            return substr($name, 0, 5) . substr($name, -5);
+        } else {
+            return $name;
+        }
     }
 
     /**


### PR DESCRIPTION
Automatically generate aliases for all modules used so we don't have to do it manually in config file for long module names. An alias should be unique relative to other aliases but short enough to leave enough room for auto-incrementing IDs. Using 10 characters as the limit allows for one hundred billion unique records, and this includes a hard limit of that number for all modules. 

Formula for a GUID:

(string 5) "seed-"
(string 10) module identifier
(string 10) time()
(int (1-11)) auto-incrementing ID

Modified from PR https://github.com/sugarcrm/Tidbit/pull/46 