### PR TITLE
All Modules and all M2M relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Installation of Vagrant Stack (Example):
     
 Configuration
 -------------
-    Tidbit have default config files in tidbit_root/config/ folder.
+    Tidbit has default config files in tidbit_root/config/ folder.
     Here:
         - config.php          -- main config file
         - data/*.php          -- customization of filling for separate fields if
@@ -90,7 +90,7 @@ Configuration
 
 Usage
 -----
-**NOTE** **Usage of Tidbit could affect on your _data_ in DB**
+**NOTE** **Usage of Tidbit could affect your _data_ in DB**
 Please make sure you have a backup, before running data Generation commands
 
 Tidbit uses a command line interface.  To run it from the Tidbit directory:
@@ -112,6 +112,9 @@ Example usages:
       
     * Generate data into csv (mysql is default):
       $ php -f install_cli.php -- --storage csv
+
+    * Generate records for all out-of-box and custom modules, plus find all relationships
+      $ php -f install_cli.php -- --allmodules --allrelationships
 
     * Obliterate all data when generating new records with 400 users:
       $php -f install_cli.php -- -o -u 400

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -38,7 +38,7 @@
 $usageStr = "Usage: " . $_SERVER['PHP_SELF'] .
     " [-l loadFactor] [-u userCount] [-x txBatchSize] [-e] [-c] [-t] [-h] [-v]\n";
 
-$versionStr = "Tidbit v2.0 -- Compatible with SugarCRM 5.5 through 6.0.\n";
+$versionStr = "Tidbit v2.0 -- Compatible with SugarCRM 5.5 and up.\n";
 $helpStr = <<<EOS
 $versionStr
 This script populates your instance of SugarCRM with realistic demo data.
@@ -76,6 +76,23 @@ Options
                     	Users and Teams.  The number of users that would normally
                     	be created is assumed to be the number of existing users.
                     	Useful for appending data onto an existing data set.
+
+    --allmodules        All Modules. Scans the Sugar system for all out-of-box
+                        and custom modules and will insert records to populate
+                        all. If modules are already configured, those 
+                        configurations are not overridden, only appended-to. The
+                        number of records created is specified by config. variable 
+                        \$all_modules_default_count, which is set to 5000 unless
+                        overridden in custom configuration. It is recommended 
+                        that this option still be used with custom configuration 
+                        to handle custom fields, one/many relationships and any 
+                        customization like custom indexes or auto-incrementing
+                        fields. 
+                        
+    --allrelationships  All Relationships. Scans the Sugar system for all out-of-box
+                        and custom relationships. If relationships are already 
+                        configured, those configurations are not overridden but 
+                        only appended-to. 
 
     --as_populate       Populate ActivityStream records for each user and module
 
@@ -140,6 +157,8 @@ $opts = getopt(
         'tba_level:',
         'tba',
         'with-tags',
+        'allmodules',
+        'allrelationships',
         'as_populate',
         'as_number:',
         'as_buffer:',
@@ -233,6 +252,27 @@ $GLOBALS['timedate']->allow_cache = false;
 
 $GLOBALS['processedRecords'] = 0;
 $GLOBALS['allProcessedRecords'] = 0;
+
+/*
+ * if user wants all modules, append system modules to existing config
+ */
+if (isset($opts['allmodules'])) {
+    global $moduleList;
+    foreach ($moduleList as $aModule) {
+        if (!isset($modules[$aModule])) {
+            $modules[$aModule] = $all_modules_default_count;
+        }
+    }
+    ksort($modules);
+}
+
+/*
+ * if user wants all relationships, append to existing config
+ */
+if (isset($opts['allrelationships'])) {
+    global $tidbit_relationships;
+    $tidbit_relationships = generate_m2m_relationship_list($tidbit_relationships);
+}
 
 $GLOBALS['modules'] = $modules;
 $GLOBALS['startTime'] = microtime();

--- a/config/config.php
+++ b/config/config.php
@@ -41,7 +41,7 @@ $tidbitCsvDir = 'csv';
 
 $defaultMaxTeamsPerSet = 10;
 
-// Default Sugar location path, could be overrided by "--sugar_path" argument
+// Default Sugar location path, could be overridden by "--sugar_path" argument
 $sugarPath = __DIR__ . '/..';
 
 $modules = array(
@@ -69,6 +69,12 @@ $modules = array(
     'Categories' => 600,
     'KBContents' => 1000,
 );
+
+/*
+ * When using --allmodules this is the number of records to create per-module
+ * when the module is not defined in the $modules array.  
+ */
+$all_modules_default_count = 5000;
 
 /*
  * Add a module alias for GUID creation. All records created will have a GUID 

--- a/install_functions.php
+++ b/install_functions.php
@@ -85,6 +85,56 @@ function generate_full_teamset($set, $teams)
 }
 
 /**
+ * Generate $tidbit_relationships array for all custom Many/Many Relationships
+ *
+ * @param array $tidbit_relationships exiting relationship configuration
+ * @return array
+ */
+function generate_m2m_relationship_list($tidbit_relationships = array())
+{
+
+    $skips = array();
+
+    global $dictionary;
+    foreach ($dictionary as $module => $field_and_rel_data) {
+        if (!isset($field_and_rel_data['relationships'])) {
+            continue;
+        }
+        foreach ($field_and_rel_data['relationships'] as $rel_name => $rel_data) {
+            if (!isset($rel_data['join_table'])) {
+                $skips[] = $rel_name;
+                continue;
+            }
+
+            $parent_module = $rel_data['lhs_module'];
+            $second_module = $rel_data['rhs_module'];
+            $self = $rel_data['join_key_lhs'];
+            $you = $rel_data['join_key_rhs'];
+            $table = $rel_data['join_table'];
+
+            if (!isset($tidbit_relationships[$parent_module])) {
+                $tidbit_relationships[$parent_module] = array();
+            }
+
+            /*
+             * don't override existing definitions
+             */
+            if (isset($tidbit_relationships[$parent_module][$second_module])) {
+                continue;
+            }
+
+            $tidbit_relationships[$parent_module][$second_module] = array(
+              'self' => $self,
+              'you' => $you,
+              'table' => $table,
+            );
+        }
+    }
+
+    return $tidbit_relationships;
+}
+
+/**
  * @param string $dir
  */
 function clearCsvDir($dir)


### PR DESCRIPTION
Adds a `-a` param to generate data for all modules and M2M relationships in the system. 

This branch includes changes from https://github.com/sugarcrm/Tidbit/pull/47 to avoid letting too-long module names in custom modules crash because of GUID length. 