### PR TITLE
ABS-972 - On DB2 vagrant stack not able to create account records

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,10 @@ Example usages:
       $php -f install_cli.php -- -o --insert_batch_size 1000
 
     * Setting path to SugarCRM installation
-      $php -f install_cli.php -- --sugar_path /some/sugar/path
+      $php -f install_cli.php -- -o --sugar_path /some/sugar/path
+
+    * Using DB2 storage example (mysql/oracle/db2 can be used, depending on Sugar installation and DB usage)
+      $php -f install_cli.php -- -o --sugar_path /some/sugar/path --storage db2
 
 Contributing:
 ------------

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -108,6 +108,7 @@ Options
     --storage name       Storage name, you have next options:
                         - mysql
                         - oracle
+                        - db2
                         - csv
 
     --sugar_path        Path to Sugar installation directory

--- a/src/DataTool.php
+++ b/src/DataTool.php
@@ -334,7 +334,8 @@ class DataTool
         }
 
         if (!empty($typeData['autoincrement'])) {
-            if ($this->storageType == \Sugarcrm\Tidbit\StorageAdapter\Factory::OUTPUT_TYPE_ORACLE
+            if ($this->storageType == Factory::OUTPUT_TYPE_ORACLE
+                || $this->storageType == Factory::OUTPUT_TYPE_DB2
             ) {
                 return strtoupper($this->table_name . '_' . $field . '_seq.nextval');
             } else {

--- a/src/Generator/Activity.php
+++ b/src/Generator/Activity.php
@@ -228,8 +228,21 @@ class Activity
      */
     public function obliterateActivities()
     {
-        return $this->db->query($this->db->truncateTableSQL(self::ACTIVITY_TABLE))
-        && $this->db->query($this->db->truncateTableSQL(self::RELATIONSHIP_TABLE));
+        return $this->db->query($this->getTruncateTableSQL(self::ACTIVITY_TABLE))
+        && $this->db->query($this->getTruncateTableSQL(self::RELATIONSHIP_TABLE));
+    }
+
+    /**
+     * Contains truncate db table logic for different DB Managers
+     *
+     * @param $tableName
+     * @return string
+     */
+    protected function getTruncateTableSQL($tableName)
+    {
+        return ($this->db->dbType == 'ibm_db2')
+            ? sprintf('ALTER TABLE %s ACTIVATE NOT LOGGED INITIALLY WITH EMPTY TABLE', $tableName)
+            : $this->db->truncateTableSQL($tableName);
     }
 
     /**

--- a/src/Generator/Categories.php
+++ b/src/Generator/Categories.php
@@ -128,7 +128,7 @@ class Categories extends Common
      */
     public function obliterateDB()
     {
-        $this->db->query($this->db->truncateTableSQL('categories'));
+        $this->db->query($this->getTruncateTableSQL('categories'));
     }
 
     /**

--- a/src/Generator/Common.php
+++ b/src/Generator/Common.php
@@ -179,6 +179,19 @@ abstract class Common
     abstract public function obliterateDB();
 
     /**
+     * Contains truncate db table logic for different DB Managers
+     *
+     * @param $tableName
+     * @return string
+     */
+    protected function getTruncateTableSQL($tableName)
+    {
+        return ($this->db->dbType == 'ibm_db2')
+            ? sprintf('ALTER TABLE %s ACTIVATE NOT LOGGED INITIALLY WITH EMPTY TABLE', $tableName)
+            : $this->db->truncateTableSQL($tableName);
+    }
+
+    /**
      * @return int
      */
     public function getInsertCounter()

--- a/src/Generator/KBContents.php
+++ b/src/Generator/KBContents.php
@@ -136,7 +136,7 @@ class KBContents extends Common
         foreach ($this->affectedTables as $table) {
             switch ($table) {
                 case 'kbusefulness':
-                    $this->db->query($this->db->truncateTableSQL('kbusefulness'));
+                    $this->db->query($this->getTruncateTableSQL('kbusefulness'));
                     break;
                 case 'notes':
                     $this->db->query("DELETE FROM notes WHERE id LIKE 'seed-%' AND parent_type = 'KBContents'");
@@ -156,7 +156,7 @@ class KBContents extends Common
             if ($table == 'notes') {
                 $this->db->query("DELETE FROM notes WHERE parent_type = 'KBContents'");
             } else {
-                $this->db->query($this->db->truncateTableSQL($table));
+                $this->db->query($this->getTruncateTableSQL($table));
             }
         }
     }

--- a/src/Generator/TBA.php
+++ b/src/Generator/TBA.php
@@ -140,7 +140,7 @@ class TBA extends Common
     public function obliterateDB()
     {
         $this->db->query("DELETE FROM acl_roles_actions WHERE role_id LIKE 'seed-%'");
-        $this->db->query($this->db->truncateTableSQL('acl_fields'));
+        $this->db->query($this->getTruncateTableSQL('acl_fields'));
     }
 
     /**

--- a/src/Generator/UserPreferences.php
+++ b/src/Generator/UserPreferences.php
@@ -80,9 +80,7 @@ class UserPreferences
      */
     public function clean()
     {
-        $this->db->query(
-            "DELETE FROM user_preferences WHERE id IN (SELECT md5(id) FROM users WHERE id != '1' AND id LIKE 'seed-%')"
-        );
+        $this->db->query("DELETE FROM user_preferences WHERE assigned_user_id LIKE 'seed-%'");
     }
 
     /**
@@ -90,7 +88,20 @@ class UserPreferences
      */
     public function obliterate()
     {
-        $this->db->query($this->db->truncateTableSQL('user_preferences'));
+        $this->db->query($this->getTruncateTableSQL('user_preferences'));
+    }
+
+    /**
+     * Contains truncate db table logic for different DB Managers
+     *
+     * @param $tableName
+     * @return string
+     */
+    protected function getTruncateTableSQL($tableName)
+    {
+        return ($this->db->dbType == 'ibm_db2')
+            ? sprintf('ALTER TABLE %s ACTIVATE NOT LOGGED INITIALLY WITH EMPTY TABLE', $tableName)
+            : $this->db->truncateTableSQL($tableName);
     }
 
     /**

--- a/src/StorageAdapter/Factory.php
+++ b/src/StorageAdapter/Factory.php
@@ -44,6 +44,7 @@ class Factory
     const OUTPUT_TYPE_MYSQL     = 'mysql';
     const OUTPUT_TYPE_ORACLE    = 'oracle';
     const OUTPUT_TYPE_CSV       = 'csv';
+    const OUTPUT_TYPE_DB2       = 'db2';
 
     /**
      * List of storage types
@@ -54,6 +55,7 @@ class Factory
         self::OUTPUT_TYPE_CSV,
         self::OUTPUT_TYPE_MYSQL,
         self::OUTPUT_TYPE_ORACLE,
+        self::OUTPUT_TYPE_DB2,
     );
 
     /**

--- a/src/StorageAdapter/Storage/Db2.php
+++ b/src/StorageAdapter/Storage/Db2.php
@@ -1,0 +1,183 @@
+<?php
+/*********************************************************************************
+ * Tidbit is a data generation tool for the SugarCRM application developed by
+ * SugarCRM, Inc. Copyright (C) 2004-2010 SugarCRM Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License version 3 as published by the
+ * Free Software Foundation with the addition of the following permission added
+ * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK
+ * IN WHICH THE COPYRIGHT IS OWNED BY SUGARCRM, SUGARCRM DISCLAIMS THE WARRANTY
+ * OF NON INFRINGEMENT OF THIRD PARTY RIGHTS.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ *
+ * You can contact SugarCRM, Inc. headquarters at 10050 North Wolfe Road,
+ * SW2-130, Cupertino, CA 95014, USA. or at email address contact@sugarcrm.com.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "Powered by
+ * SugarCRM" logo. If the display of the logo is not reasonably feasible for
+ * technical reasons, the Appropriate Legal Notices must display the words
+ * "Powered by SugarCRM".
+ ********************************************************************************/
+
+namespace Sugarcrm\Tidbit\StorageAdapter\Storage;
+
+use Sugarcrm\Tidbit\Exception;
+use Sugarcrm\Tidbit\StorageAdapter\Factory;
+
+class Db2 extends Common
+{
+    /**
+     * @var string
+     */
+    const STORE_TYPE = Factory::OUTPUT_TYPE_DB2;
+
+    /**
+     * {@inheritdoc}
+     *
+     */
+    public function save($tableName, array $installData)
+    {
+        $sql = $this->prepareQuery($tableName, $installData);
+        $this->logQuery($sql);
+        $this->storageResource->query($sql, true, "INSERT QUERY FAILED");
+        $this->commitQuery();
+    }
+
+    /**
+     * rtfn
+     *
+     * @param string $tableName
+     * @param array $installData
+     * @return string
+     * @throws \Sugarcrm\Tidbit\Exception
+     */
+    protected function prepareQuery($tableName, array $installData)
+    {
+        if (!$tableName || !$installData) {
+            throw new Exception("DB2 adapter error: wrong data to insert");
+        }
+
+        $columns = " (" . implode(", ", array_keys($installData[0])) . ")";
+        $sql = 'INSERT INTO ' . $tableName . $columns;
+
+        $this->patchSequenceValues($installData);
+        $insertRecords = count($installData);
+
+        for ($i = 0; $i < $insertRecords; $i++) {
+            $sql .= ' VALUES ' . "(" . implode(", ", $installData[$i]) . ")";
+            $sql .= ($i + 1 < $insertRecords) ? ' UNION ALL' : '';
+        }
+
+        return $sql;
+    }
+
+    /**
+     * Patch inserted value if it look like sequence
+     *
+     * @param array $installData
+     */
+    protected function patchSequenceValues(array &$installData)
+    {
+        if (!$sequence = $this->getSequenceFromValues($installData[0])) {
+            return;
+        }
+
+        $installDataCount = count($installData);
+        $currentValue = $this->getCurrentSequenceValue($sequence['name']);
+
+        for ($i=0; $i <$installDataCount; $i++) {
+            $installData[$i][$sequence['field']] = ++$currentValue;
+        }
+
+        $this->setNewSequenceValue($sequence['name'], $installDataCount);
+    }
+
+    /**
+     * Check array of values on containing sequence value
+     *
+     * @param array $values
+     * @return array
+     */
+    protected function getSequenceFromValues(array $values)
+    {
+        foreach ($values as $k => $v) {
+            if (substr($v, -12) == '_SEQ.NEXTVAL') {
+                return array('field' => $k, 'name' => substr($v, 0, -8));
+            }
+        }
+        return array();
+    }
+
+    /**
+     * rtfn
+     *
+     * @param string $sequenceName
+     * @return int
+     */
+    protected function getCurrentSequenceValue($sequenceName)
+    {
+        $sql = sprintf(
+            "SELECT last_number as current_val FROM user_sequences WHERE sequence_name='%s'",
+            $sequenceName
+        );
+        
+        $result = $this->storageResource->query($sql);
+        $row = $this->storageResource->fetchByAssoc($result);
+
+        $currentValue = intval($row['current_val']);
+
+        // sequence was RESET or not initialized, force NEXT VALUE to start sequence
+        if ($currentValue < 0) {
+            $sql = sprintf("SELECT %s.nextval FROM SYSIBM.SYSDUMMY1;", $sequenceName);
+            $this->storageResource->query($sql);
+
+            $sql = sprintf(
+                "SELECT last_number as current_val FROM user_sequences WHERE sequence_name='%s'",
+                $sequenceName
+            );
+
+            $result = $this->storageResource->query($sql);
+            $row = $this->storageResource->fetchByAssoc($result);
+
+            $currentValue = intval($row['current_val']);
+        }
+
+        return $currentValue;
+    }
+
+    /**
+     * rtfn
+     *
+     * @param string $sequenceName
+     * @param int $incrementOn
+     */
+    protected function setNewSequenceValue($sequenceName, $incrementOn)
+    {
+        // set increment value to our batch_size
+        $sql = sprintf("ALTER SEQUENCE %s INCREMENT BY %d", $sequenceName, $incrementOn);
+        $this->storageResource->query($sql);
+
+        // do increment
+        $sql = sprintf("SELECT %s.nextval FROM SYSIBM.SYSDUMMY1;", $sequenceName);
+        $this->storageResource->query($sql);
+
+        // return increment value to 1
+        $sql = sprintf("ALTER SEQUENCE %s INCREMENT BY 1", $sequenceName);
+        $this->storageResource->query($sql);
+    }
+}

--- a/tests/StorageAdapter/Storage/Db2Test.php
+++ b/tests/StorageAdapter/Storage/Db2Test.php
@@ -1,0 +1,284 @@
+<?php
+
+namespace Sugarcrm\Tidbit\Tests\StorageAdapter\Storage;
+
+use Sugarcrm\Tidbit\Tests\TidbitTestCase;
+use Sugarcrm\Tidbit\StorageAdapter\Storage\Db2;
+
+/**
+ * Class Db2Test
+ * @package Sugarcrm\Tidbit\Tests\StorageAdapter\Storage
+ *
+ * @coversDefaultClass \Sugarcrm\Tidbit\StorageAdapter\Storage\Db2
+ */
+class Db2Test extends TidbitTestCase
+{
+    /** @var mixed */
+    protected $storageResource;
+
+    /**
+     * @covers ::getSequenceFromValues
+     */
+    public function testGetSequenceFromValuesWithEmptyData()
+    {
+        $storage = new Db2($this->storageResource);
+
+        $method = static::accessNonPublicMethod('\Sugarcrm\Tidbit\StorageAdapter\Storage\Db2', 'getSequenceFromValues');
+        $installData = array();
+        $actual = $method->invokeArgs($storage, array($installData));
+
+        $this->assertEmpty($actual);
+    }
+
+    /**
+     * @covers ::getSequenceFromValues
+     */
+    public function testGetSequenceFromValues()
+    {
+        $storage = new Db2($this->storageResource);
+
+        $method = static::accessNonPublicMethod('\Sugarcrm\Tidbit\StorageAdapter\Storage\Db2', 'getSequenceFromValues');
+
+        $installData = array(
+            'some_field' => 'some_value',
+            'field_name' => 'CASES_CASE_NUMBER_SEQ.NEXTVAL',
+        );
+
+        $actual = $method->invokeArgs($storage, array($installData));
+
+        $this->assertEquals(array('field' => 'field_name', 'name' => 'CASES_CASE_NUMBER_SEQ'), $actual);
+    }
+
+    /**
+     * Due to issue in Storage classes, we can process only one sequence per table
+     * TODO: Fix DB2 and Oracle classes to support multiple sequences per table
+     *
+     * @covers ::getSequenceFromValues
+     */
+    public function testGetSequenceFromValuesIgnoreSecondSequence()
+    {
+        $storage = new Db2($this->storageResource);
+
+        $method = static::accessNonPublicMethod('\Sugarcrm\Tidbit\StorageAdapter\Storage\Db2', 'getSequenceFromValues');
+
+        $installData = array(
+            'some_field' => 'some_value',
+            'field_name' => 'CASES_CASE_NUMBER_SEQ.NEXTVAL',
+            'field_name2' => 'CASES_CASE_NUMBER2_SEQ.NEXTVAL',
+        );
+
+        $actual = $method->invokeArgs($storage, array($installData));
+
+        $this->assertEquals(array('field' => 'field_name', 'name' => 'CASES_CASE_NUMBER_SEQ'), $actual);
+    }
+
+    /**
+     * @covers ::getCurrentSequenceValue
+     */
+    public function testGetCurrentSequenceValue()
+    {
+        $mock = $this->getMock('\Sugarcrm\Tidbit\Tests\SugarObject\DBManager', array('query', 'fetchByAssoc'));
+        $expectedValue = 10;
+
+        $mock->expects($this->once())
+            ->method('query')
+            ->willReturn(true);
+
+        $mock->expects($this->once())
+            ->method('fetchByAssoc')
+            ->willReturn(array('current_val' => $expectedValue));
+
+        $storage = new Db2($mock);
+        $method = static::accessNonPublicMethod(
+            '\Sugarcrm\Tidbit\StorageAdapter\Storage\Db2',
+            'getCurrentSequenceValue'
+        );
+
+        $actual = $method->invokeArgs($storage, array('some_sequence_name'));
+        $this->assertEquals($expectedValue, $actual);
+    }
+
+    /**
+     * @covers ::getCurrentSequenceValue
+     */
+    public function testGetCurrentSequenceValueReloadSequence()
+    {
+        $mock = $this->getMock('\Sugarcrm\Tidbit\Tests\SugarObject\DBManager', array('query', 'fetchByAssoc'));
+        $expectedValue = 1;
+
+        $mock->expects($this->exactly(3))
+            ->method('query')
+            ->willReturn(true);
+
+        $mock->expects($this->exactly(2))
+            ->method('fetchByAssoc')
+            ->will($this->onConsecutiveCalls(array('current_val' => -1), array('current_val' => $expectedValue)));
+
+        $storage = new Db2($mock);
+        $method = static::accessNonPublicMethod(
+            '\Sugarcrm\Tidbit\StorageAdapter\Storage\Db2',
+            'getCurrentSequenceValue'
+        );
+
+        $actual = $method->invokeArgs($storage, array('some_sequence_name'));
+        $this->assertEquals($expectedValue, $actual);
+    }
+
+    /**
+     * @covers ::patchSequenceValues
+     */
+    public function testPatchSequenceValuesShouldReturnEmptyStringIfSequenceIsNotFound()
+    {
+        $installData = array(
+            array(
+                'some_field' => 'some_value',
+            ),
+        );
+
+        $mock = $this->getMockBuilder('Sugarcrm\Tidbit\StorageAdapter\Storage\Db2')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getSequenceFromValues', 'getCurrentSequenceValue', 'setNewSequenceValue'))
+            ->getMock();
+
+        $mock->expects($this->once())
+            ->method('getSequenceFromValues')
+            ->with($installData[0])
+            ->willReturn(array());
+
+        $method = static::accessNonPublicMethod('\Sugarcrm\Tidbit\StorageAdapter\Storage\Db2', 'patchSequenceValues');
+        $actual = $method->invokeArgs($mock, array(&$installData));
+
+        $this->assertEmpty($actual);
+    }
+
+    /**
+     * @covers ::patchSequenceValues
+     */
+    public function testPatchSequenceValues()
+    {
+        $currentSequenceValue = 5;
+        $installData = array(
+            array(
+                'some_field' => 'some_value',
+                'field_name' => 'CASES_CASE_NUMBER_SEQ.NEXTVAL',
+            ),
+            array(
+                'some_field' => 'some_value2',
+                'field_name' => 'CASES_CASE_NUMBER_SEQ.NEXTVAL',
+            ),
+            array(
+                'some_field' => 'some_value2',
+                'field_name' => 'CASES_CASE_NUMBER_SEQ.NEXTVAL',
+            ),
+        );
+
+        $mock = $this->getMockBuilder('Sugarcrm\Tidbit\StorageAdapter\Storage\Db2')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getSequenceFromValues', 'getCurrentSequenceValue', 'setNewSequenceValue'))
+            ->getMock();
+
+        $mock->expects($this->once())
+            ->method('getSequenceFromValues')
+            ->with($installData[0])
+            ->willReturn(array('field' => 'field_name', 'name' => 'CASES_CASE_NUMBER_SEQ'));
+
+        $mock->expects($this->once())
+            ->method('getCurrentSequenceValue')
+            ->with('CASES_CASE_NUMBER_SEQ')
+            ->willReturn($currentSequenceValue);
+
+        $mock->expects($this->once())
+            ->method('setNewSequenceValue')
+            ->with('CASES_CASE_NUMBER_SEQ', count($installData))
+            ->willReturn(true);
+
+        $method = static::accessNonPublicMethod('\Sugarcrm\Tidbit\StorageAdapter\Storage\Db2', 'patchSequenceValues');
+        $method->invokeArgs($mock, array(&$installData));
+
+        // Assert that values were changed to current sequence value + iteration number
+        for ($i = 0; $i < count($installData); $i++) {
+            $this->assertEquals($currentSequenceValue + $i + 1, $installData[$i]['field_name']);
+        }
+    }
+
+    /**
+     * @covers ::prepareQuery
+     * @dataProvider dataTestPrepareQueryExceptionProvider
+     * @expectedException \Sugarcrm\Tidbit\Exception
+     *
+     * @param string $tableName
+     * @param mixed $installData
+     */
+    public function testPrepareQueryException($tableName, $installData)
+    {
+        $mock = $this->getMockBuilder('Sugarcrm\Tidbit\StorageAdapter\Storage\Db2')
+            ->disableOriginalConstructor()
+            ->setMethods(array('patchSequenceValues'))
+            ->getMock();
+
+        $mock->expects($this->never())
+            ->method('patchSequenceValues');
+
+        $method = static::accessNonPublicMethod('\Sugarcrm\Tidbit\StorageAdapter\Storage\Db2', 'prepareQuery');
+        $method->invokeArgs($mock, array($tableName, $installData));
+    }
+
+    /**
+     * @see testPrepareQueryException
+     * @return array
+     */
+    public function dataTestPrepareQueryExceptionProvider()
+    {
+        return array(
+            array(
+                '',
+                array(),
+            ),
+            array(
+                'some_table',
+                array(),
+            ),
+            array(
+                '',
+                array('1', '2', '3'),
+            )
+        );
+    }
+
+    /**
+     * @covers ::prepareQuery
+     */
+    public function testPrepareQuery()
+    {
+        $installData = array(
+            array(
+                'some_field' => 'some_value',
+                'field_name' => 'CASES_CASE_NUMBER_SEQ.NEXTVAL',
+            ),
+            array(
+                'some_field' => 'some_value2',
+                'field_name' => 'CASES_CASE_NUMBER_SEQ.NEXTVAL',
+            ),
+            array(
+                'some_field' => 'some_value2',
+                'field_name' => 'CASES_CASE_NUMBER_SEQ.NEXTVAL',
+            ),
+        );
+
+        $mock = $this->getMockBuilder('Sugarcrm\Tidbit\StorageAdapter\Storage\Db2')
+            ->disableOriginalConstructor()
+            ->setMethods(array('patchSequenceValues'))
+            ->getMock();
+
+        $mock->expects($this->once())
+            ->method('patchSequenceValues')
+            ->with($installData);
+
+        $method = static::accessNonPublicMethod('\Sugarcrm\Tidbit\StorageAdapter\Storage\Db2', 'prepareQuery');
+        $actual = $method->invokeArgs($mock, array('some_table', $installData));
+
+        // For 3 records prepareQuery should put 2 "UNION ALL" into final SQL
+        $this->assertEquals(2, substr_count($actual, 'UNION ALL'));
+        $this->assertEquals(3, substr_count($actual, 'VALUES ('));
+    }
+}

--- a/tests/StorageAdapter/Storage/OracleTest.php
+++ b/tests/StorageAdapter/Storage/OracleTest.php
@@ -1,0 +1,276 @@
+<?php
+
+namespace Sugarcrm\Tidbit\Tests\StorageAdapter\Storage;
+
+use Sugarcrm\Tidbit\Tests\TidbitTestCase;
+use Sugarcrm\Tidbit\StorageAdapter\Storage\Oracle;
+
+/**
+ * Class OracleTest
+ * @package Sugarcrm\Tidbit\Tests\StorageAdapter\Storage
+ *
+ * @coversDefaultClass \Sugarcrm\Tidbit\StorageAdapter\Storage\Oracle
+ */
+class OracleTest extends TidbitTestCase
+{
+    /** @var mixed */
+    protected $storageResource;
+
+    /**
+     * @covers ::getSequenceFromValues
+     */
+    public function testGetSequenceFromValuesWithEmptyData()
+    {
+        $storage = new Oracle($this->storageResource);
+
+        $method = static::accessNonPublicMethod(
+            '\Sugarcrm\Tidbit\StorageAdapter\Storage\Oracle',
+            'getSequenceFromValues'
+        );
+
+        $installData = array();
+        $actual = $method->invokeArgs($storage, array($installData));
+
+        $this->assertEmpty($actual);
+    }
+
+    /**
+     * @covers ::getSequenceFromValues
+     */
+    public function testGetSequenceFromValues()
+    {
+        $storage = new Oracle($this->storageResource);
+
+        $method = static::accessNonPublicMethod(
+            '\Sugarcrm\Tidbit\StorageAdapter\Storage\Oracle',
+            'getSequenceFromValues'
+        );
+
+        $installData = array(
+            'some_field' => 'some_value',
+            'field_name' => 'CASES_CASE_NUMBER_SEQ.NEXTVAL',
+        );
+
+        $actual = $method->invokeArgs($storage, array($installData));
+
+        $this->assertEquals(array('field' => 'field_name', 'name' => 'CASES_CASE_NUMBER_SEQ'), $actual);
+    }
+
+    /**
+     * Due to issue in Storage classes, we can process only one sequence per table
+     * TODO: Fix DB2 and Oracle classes to support multiple sequences per table
+     *
+     * @covers ::getSequenceFromValues
+     */
+    public function testGetSequenceFromValuesIgnoreSecondSequence()
+    {
+        $storage = new Oracle($this->storageResource);
+
+        $method = static::accessNonPublicMethod(
+            '\Sugarcrm\Tidbit\StorageAdapter\Storage\Oracle',
+            'getSequenceFromValues'
+        );
+
+        $installData = array(
+            'some_field' => 'some_value',
+            'field_name' => 'CASES_CASE_NUMBER_SEQ.NEXTVAL',
+            'field_name2' => 'CASES_CASE_NUMBER2_SEQ.NEXTVAL',
+        );
+
+        $actual = $method->invokeArgs($storage, array($installData));
+
+        $this->assertEquals(array('field' => 'field_name', 'name' => 'CASES_CASE_NUMBER_SEQ'), $actual);
+    }
+
+    /**
+     * @covers ::getCurrentSequenceValue
+     */
+    public function testGetCurrentSequenceValue()
+    {
+        $mock = $this->getMock('\Sugarcrm\Tidbit\Tests\SugarObject\DBManager', array('query', 'fetchByAssoc'));
+        $expectedValue = 10;
+
+        $mock->expects($this->once())
+            ->method('query')
+            ->willReturn(true);
+
+        $mock->expects($this->once())
+            ->method('fetchByAssoc')
+            ->willReturn(array('current_val' => $expectedValue));
+
+        $storage = new Oracle($mock);
+        $method = static::accessNonPublicMethod(
+            '\Sugarcrm\Tidbit\StorageAdapter\Storage\Oracle',
+            'getCurrentSequenceValue'
+        );
+
+        $actual = $method->invokeArgs($storage, array('some_sequence_name'));
+        $this->assertEquals($expectedValue, $actual);
+    }
+
+    /**
+     * @covers ::patchSequenceValues
+     */
+    public function testPatchSequenceValuesShouldReturnEmptyStringIfSequenceIsNotFound()
+    {
+        $installData = array(
+            array(
+                'some_field' => 'some_value',
+            ),
+        );
+
+        $mock = $this->getMockBuilder('Sugarcrm\Tidbit\StorageAdapter\Storage\Oracle')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getSequenceFromValues', 'getCurrentSequenceValue', 'setNewSequenceValue'))
+            ->getMock();
+
+        $mock->expects($this->once())
+            ->method('getSequenceFromValues')
+            ->with($installData[0])
+            ->willReturn(array());
+
+        $method = static::accessNonPublicMethod(
+            '\Sugarcrm\Tidbit\StorageAdapter\Storage\Oracle',
+            'patchSequenceValues'
+        );
+
+        $actual = $method->invokeArgs($mock, array(&$installData));
+
+        $this->assertEmpty($actual);
+    }
+
+    /**
+     * @covers ::patchSequenceValues
+     */
+    public function testPatchSequenceValues()
+    {
+        $currentSequenceValue = 5;
+        $installData = array(
+            array(
+                'some_field' => 'some_value',
+                'field_name' => 'CASES_CASE_NUMBER_SEQ.NEXTVAL',
+            ),
+            array(
+                'some_field' => 'some_value2',
+                'field_name' => 'CASES_CASE_NUMBER_SEQ.NEXTVAL',
+            ),
+            array(
+                'some_field' => 'some_value2',
+                'field_name' => 'CASES_CASE_NUMBER_SEQ.NEXTVAL',
+            ),
+        );
+
+        $mock = $this->getMockBuilder('Sugarcrm\Tidbit\StorageAdapter\Storage\Oracle')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getSequenceFromValues', 'getCurrentSequenceValue', 'setNewSequenceValue'))
+            ->getMock();
+
+        $mock->expects($this->once())
+            ->method('getSequenceFromValues')
+            ->with($installData[0])
+            ->willReturn(array('field' => 'field_name', 'name' => 'CASES_CASE_NUMBER_SEQ'));
+
+        $mock->expects($this->once())
+            ->method('getCurrentSequenceValue')
+            ->with('CASES_CASE_NUMBER_SEQ')
+            ->willReturn($currentSequenceValue);
+
+        $mock->expects($this->once())
+            ->method('setNewSequenceValue')
+            ->with('CASES_CASE_NUMBER_SEQ', count($installData))
+            ->willReturn(true);
+
+        $method = static::accessNonPublicMethod(
+            '\Sugarcrm\Tidbit\StorageAdapter\Storage\Oracle',
+            'patchSequenceValues'
+        );
+
+        $method->invokeArgs($mock, array(&$installData));
+
+        // Assert that values were changed to current sequence value + iteration number
+        for ($i = 0; $i < count($installData); $i++) {
+            $this->assertEquals($currentSequenceValue + $i + 1, $installData[$i]['field_name']);
+        }
+    }
+
+    /**
+     * @covers ::prepareQuery
+     * @dataProvider dataTestPrepareQueryExceptionProvider
+     * @expectedException \Sugarcrm\Tidbit\Exception
+     *
+     * @param string $tableName
+     * @param mixed $installData
+     */
+    public function testPrepareQueryException($tableName, $installData)
+    {
+        $mock = $this->getMockBuilder('Sugarcrm\Tidbit\StorageAdapter\Storage\Oracle')
+            ->disableOriginalConstructor()
+            ->setMethods(array('patchSequenceValues'))
+            ->getMock();
+
+        $mock->expects($this->never())
+            ->method('patchSequenceValues');
+
+        $method = static::accessNonPublicMethod('\Sugarcrm\Tidbit\StorageAdapter\Storage\Oracle', 'prepareQuery');
+        $method->invokeArgs($mock, array($tableName, $installData));
+    }
+
+    /**
+     * @see testPrepareQueryException
+     * @return array
+     */
+    public function dataTestPrepareQueryExceptionProvider()
+    {
+        return array(
+            array(
+                '',
+                array(),
+            ),
+            array(
+                'some_table',
+                array(),
+            ),
+            array(
+                '',
+                array('1', '2', '3'),
+            )
+        );
+    }
+
+    /**
+     * @covers ::prepareQuery
+     */
+    public function testPrepareQuery()
+    {
+        $installData = array(
+            array(
+                'some_field' => 'some_value',
+                'field_name' => 'CASES_CASE_NUMBER_SEQ.NEXTVAL',
+            ),
+            array(
+                'some_field' => 'some_value2',
+                'field_name' => 'CASES_CASE_NUMBER_SEQ.NEXTVAL',
+            ),
+            array(
+                'some_field' => 'some_value2',
+                'field_name' => 'CASES_CASE_NUMBER_SEQ.NEXTVAL',
+            ),
+        );
+
+        $mock = $this->getMockBuilder('Sugarcrm\Tidbit\StorageAdapter\Storage\Oracle')
+            ->disableOriginalConstructor()
+            ->setMethods(array('patchSequenceValues'))
+            ->getMock();
+
+        $mock->expects($this->once())
+            ->method('patchSequenceValues')
+            ->with($installData);
+
+        $method = static::accessNonPublicMethod('\Sugarcrm\Tidbit\StorageAdapter\Storage\Oracle', 'prepareQuery');
+        $actual = $method->invokeArgs($mock, array('some_table', $installData));
+        
+        $this->assertContains('INSERT /*+APPEND*/ ALL', $actual);
+        $this->assertEquals(3, substr_count($actual, 'VALUES ('));
+        $this->assertContains('SELECT * FROM dual', $actual);
+    }
+}

--- a/tests/SugarObject/DBManager.php
+++ b/tests/SugarObject/DBManager.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Sugarcrm\Tidbit\Tests\SugarObject;
+
+/**
+ * Class DBManager
+ * @package Sugarcrm\Tidbit\Tests\SugarObject
+ */
+class DBManager
+{
+    public function query($sql, $dieOnFailure = false, $message = '')
+    {
+        return true;
+    }
+
+    public function fetchByAssoc($statement)
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
ABS-972 - On DB2 vagrant stack not able to create account records

- DB2 storage class
- Truncate statements are optimised for DB2
- Tested -o, -c, -e usage cases of Tidbit on sugar db2 stack