### PR TITLE
ABS-972 - Fix DB2 get current sequence value

### DIFF
--- a/src/StorageAdapter/Storage/Db2.php
+++ b/src/StorageAdapter/Storage/Db2.php
@@ -132,32 +132,14 @@ class Db2 extends Common
     protected function getCurrentSequenceValue($sequenceName)
     {
         $sql = sprintf(
-            "SELECT last_number as current_val FROM user_sequences WHERE sequence_name='%s'",
+            "SELECT lastassignedval AS current_val FROM SYSIBM.SYSSEQUENCES WHERE seqname = '%s'",
             $sequenceName
         );
         
         $result = $this->storageResource->query($sql);
         $row = $this->storageResource->fetchByAssoc($result);
 
-        $currentValue = intval($row['current_val']);
-
-        // sequence was RESET or not initialized, force NEXT VALUE to start sequence
-        if ($currentValue < 0) {
-            $sql = sprintf("SELECT %s.nextval FROM SYSIBM.SYSDUMMY1;", $sequenceName);
-            $this->storageResource->query($sql);
-
-            $sql = sprintf(
-                "SELECT last_number as current_val FROM user_sequences WHERE sequence_name='%s'",
-                $sequenceName
-            );
-
-            $result = $this->storageResource->query($sql);
-            $row = $this->storageResource->fetchByAssoc($result);
-
-            $currentValue = intval($row['current_val']);
-        }
-
-        return $currentValue;
+        return intval($row['current_val']);
     }
 
     /**

--- a/tests/StorageAdapter/Storage/Db2Test.php
+++ b/tests/StorageAdapter/Storage/Db2Test.php
@@ -99,32 +99,6 @@ class Db2Test extends TidbitTestCase
     }
 
     /**
-     * @covers ::getCurrentSequenceValue
-     */
-    public function testGetCurrentSequenceValueReloadSequence()
-    {
-        $mock = $this->getMock('\Sugarcrm\Tidbit\Tests\SugarObject\DBManager', array('query', 'fetchByAssoc'));
-        $expectedValue = 1;
-
-        $mock->expects($this->exactly(3))
-            ->method('query')
-            ->willReturn(true);
-
-        $mock->expects($this->exactly(2))
-            ->method('fetchByAssoc')
-            ->will($this->onConsecutiveCalls(array('current_val' => -1), array('current_val' => $expectedValue)));
-
-        $storage = new Db2($mock);
-        $method = static::accessNonPublicMethod(
-            '\Sugarcrm\Tidbit\StorageAdapter\Storage\Db2',
-            'getCurrentSequenceValue'
-        );
-
-        $actual = $method->invokeArgs($storage, array('some_sequence_name'));
-        $this->assertEquals($expectedValue, $actual);
-    }
-
-    /**
      * @covers ::patchSequenceValues
      */
     public function testPatchSequenceValuesShouldReturnEmptyStringIfSequenceIsNotFound()


### PR DESCRIPTION
ABS-972 - Fix DB2 get current sequence value

- Replace "user_sequences" with "SYSIBM.SYSSEQUENCES" to get current sequence value