### PR TITLE
Optional Composer Autoload

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -202,7 +202,18 @@ define('PROFILES_DIR', CONFIG_DIR . '/profiles');
 define('DATA_DIR', CONFIG_DIR . '/data');
 define('RELATIONSHIPS_DIR', CONFIG_DIR . '/relationships');
 
-require_once __DIR__ . '/vendor/autoload.php';
+/*
+ * if Tidbit is running independently, the dependencies are in the /vendor
+ * directory, but if Tidbit is part of a larger composer managed system, the
+ * dependencies are a couple directories higher. If neither are found, bail
+ */
+if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+    require_once __DIR__ . '/vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '../../autoload.php')) {
+    require_once __DIR__ . '../../autoload.php';
+} else {
+    exitWithError('Unable to locate composer\'s autoload.php file');
+}
 
 // load general config
 require_once CONFIG_DIR . '/config.php';
@@ -322,7 +333,7 @@ if (isset($opts['l']) && !isset($opts['profile'])) {
         $modules[$m] *= $factor;
     }
     
-    // Multiple favorites with $factor too 
+    // Multiple favorites with $factor too
     if (isset($opts['with-favorites'])) {
         foreach ($sugarFavoritesModules as $m => $n) {
             $sugarFavoritesModules[$m] *= $factor;


### PR DESCRIPTION
Only require & load /vendor/autoload.php if the file exists. We only need composer-loaded dependencies to run tests & debug, so we don't need necessarily need these. 

For context, I'll be including Tidbit in a custom Sugar system's composer.json sans the require/require-dev parameters, since they don't seem to actually be required to _use_ Tidbit. This `require_once()` seems to be the only thing preventing me from running it. 

If there's another way of letting Tidbit know that it's dependencies are located somewhere other than here, I'd be open to that instead. 