### PR TITLE
Teamset of random number of teams

### DIFF
--- a/src/Generator/TeamSets.php
+++ b/src/Generator/TeamSets.php
@@ -203,7 +203,6 @@ class TeamSets extends \TeamSet
     {
         $stats = $this->_getStatistics($teams);
         $team_md5 = $stats['team_md5'];
-        $teams = $stats['team_ids'];
 
         if (!in_array($team_md5, $this->teamMd5Array)) {
             if (count($teams) == 1) {
@@ -252,10 +251,10 @@ class TeamSets extends \TeamSet
     {
         $result = array();
 
-        for ($i = 0; $i < $num; $i++) {
+        for ($i = 0; $i < mt_rand(1, $num); $i++) {
             $result[$i] = $array[mt_rand(0, count($array) - 1)];
         }
-        return $result;
+        return array_unique($result);
     }
 
     /**


### PR DESCRIPTION
Commit 474895922 made getRandomArray method to
return the array of $num elements, while befor that commit
it used to return $num elements at maximum. This commit
brings this behavior back again.