### PR TITLE
[ABS-1700] - Tidbit is failing on Sugar 8.3 build 57 and later.

### DIFF
--- a/config/profiles/baseline.php
+++ b/config/profiles/baseline.php
@@ -33,6 +33,11 @@ $modules = array(
     'Manufacturers' => 1000,
 );
 
+$aliases = [
+    'ProductTemplatesFavorites' => 'ProdTPLFav',
+    'ProductsFavorites' => 'ProdFav',
+];
+
 $profile_opts = array(
 
 );

--- a/config/profiles/simple.php
+++ b/config/profiles/simple.php
@@ -33,6 +33,11 @@ $modules = array(
     'Manufacturers' => 100,
 );
 
+$aliases = [
+    'ProductTemplatesFavorites' => 'ProdTPLFav',
+    'ProductsFavorites' => 'ProdFav',
+];
+
 $profile_opts = array(
 
 );

--- a/config/profiles/trivial.php
+++ b/config/profiles/trivial.php
@@ -68,6 +68,11 @@ $modules = array(
     'Manufacturers' => 10,
 );
 
+$aliases = [
+    'ProductTemplatesFavorites' => 'ProdTPLFav',
+    'ProductsFavorites' => 'ProdFav',
+];
+
 $profile_opts = array(
 
 );


### PR DESCRIPTION
Added aliases to Product*Favorites module names to prevent sugarfavorites id collisions.