### PR TITLE
Add generation rules for 'longtext' type

### DIFF
--- a/config/data/DefaultData.php
+++ b/config/data/DefaultData.php
@@ -49,6 +49,7 @@ $GLOBALS['dataTool']['default']['short'] = array('range' => array('min' => 0, 'm
 $GLOBALS['dataTool']['default']['varchar'] = array('list' => 'last_name_array');
 // $GLOBALS['dataTool']['default']['text'] = array('gibberish' => -1);
 $GLOBALS['dataTool']['default']['text'] = ['value' => "''"];
+$GLOBALS['dataTool']['default']['longtext'] = $GLOBALS['dataTool']['default']['text'];
 $GLOBALS['dataTool']['default']['date'] = [
     'range' => ['min' => -30, 'max' => 30],
     'type' => 'date',


### PR DESCRIPTION
Module Calls brings new fields 'agent_transcript' and
'customer_transcript' with Sugar 10.3.0.
These fields contains following attributes:
	'type' => 'textarea',
	'dbType' => 'longtext',
For fixing Tidbit's error the same rule was applied for them as
for 'text' field.