### PR TITLE
Fix 'Arbitrary shell execution' Dependabot alert

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "4.*",
-    "squizlabs/php_codesniffer": "2.6"
+    "squizlabs/php_codesniffer": "2.8.1"
   },
   "autoload" : {
     "psr-4" : {


### PR DESCRIPTION
Package squizlabs/php_codesniffer
Affected versions >= 1.0.0, < 2.8.1
Patched version 2.8.1

Uses of shell_exec() and exec() were not escaping filenames and configuration settings in most cases